### PR TITLE
Pin mobx-state-tree to 5.x to fix blank GitHub Pages render

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@jbrowse/react-linear-genome-view": "^3.1.0",
         "mobx": "^6.15.0",
         "mobx-react": "^9.2.1",
-        "mobx-state-tree": "^7.0.2",
+        "mobx-state-tree": "^5.4.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "vite-plugin-node-polyfills": "^0.25.0"
@@ -1464,15 +1464,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@jbrowse/core/node_modules/mobx-state-tree": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.4.2.tgz",
-      "integrity": "sha512-SGXAh2KCBQbWVcxeQbZEr5pchTgcfNZmGVRL2a2Me+pSMH98bZWXD6EOuuijbTGbc0hOoOsbab3JdwJyr+fW7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "mobx": "^6.3.0"
-      }
-    },
     "node_modules/@jbrowse/core/node_modules/pako-esm2": {
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/pako-esm2/-/pako-esm2-1.0.15.tgz",
@@ -1500,15 +1491,6 @@
       "peerDependencies": {
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
-      }
-    },
-    "node_modules/@jbrowse/embedded-core/node_modules/mobx-state-tree": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.4.2.tgz",
-      "integrity": "sha512-SGXAh2KCBQbWVcxeQbZEr5pchTgcfNZmGVRL2a2Me+pSMH98bZWXD6EOuuijbTGbc0hOoOsbab3JdwJyr+fW7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "mobx": "^6.3.0"
       }
     },
     "node_modules/@jbrowse/plugin-alignments": {
@@ -1539,15 +1521,6 @@
         "react": ">=18.0.0"
       }
     },
-    "node_modules/@jbrowse/plugin-alignments/node_modules/mobx-state-tree": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.4.2.tgz",
-      "integrity": "sha512-SGXAh2KCBQbWVcxeQbZEr5pchTgcfNZmGVRL2a2Me+pSMH98bZWXD6EOuuijbTGbc0hOoOsbab3JdwJyr+fW7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "mobx": "^6.3.0"
-      }
-    },
     "node_modules/@jbrowse/plugin-arc": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@jbrowse/plugin-arc/-/plugin-arc-3.7.0.tgz",
@@ -1568,15 +1541,6 @@
         "react-dom": ">=18.0.0"
       }
     },
-    "node_modules/@jbrowse/plugin-arc/node_modules/mobx-state-tree": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.4.2.tgz",
-      "integrity": "sha512-SGXAh2KCBQbWVcxeQbZEr5pchTgcfNZmGVRL2a2Me+pSMH98bZWXD6EOuuijbTGbc0hOoOsbab3JdwJyr+fW7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "mobx": "^6.3.0"
-      }
-    },
     "node_modules/@jbrowse/plugin-authentication": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@jbrowse/plugin-authentication/-/plugin-authentication-3.7.0.tgz",
@@ -1595,15 +1559,6 @@
       "peerDependencies": {
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
-      }
-    },
-    "node_modules/@jbrowse/plugin-authentication/node_modules/mobx-state-tree": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.4.2.tgz",
-      "integrity": "sha512-SGXAh2KCBQbWVcxeQbZEr5pchTgcfNZmGVRL2a2Me+pSMH98bZWXD6EOuuijbTGbc0hOoOsbab3JdwJyr+fW7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "mobx": "^6.3.0"
       }
     },
     "node_modules/@jbrowse/plugin-bed": {
@@ -1637,15 +1592,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@jbrowse/plugin-bed/node_modules/mobx-state-tree": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.4.2.tgz",
-      "integrity": "sha512-SGXAh2KCBQbWVcxeQbZEr5pchTgcfNZmGVRL2a2Me+pSMH98bZWXD6EOuuijbTGbc0hOoOsbab3JdwJyr+fW7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "mobx": "^6.3.0"
-      }
-    },
     "node_modules/@jbrowse/plugin-bed/node_modules/pako-esm2": {
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/pako-esm2/-/pako-esm2-1.0.15.tgz",
@@ -1673,15 +1619,6 @@
         "react-dom": ">=18.0.0"
       }
     },
-    "node_modules/@jbrowse/plugin-circular-view/node_modules/mobx-state-tree": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.4.2.tgz",
-      "integrity": "sha512-SGXAh2KCBQbWVcxeQbZEr5pchTgcfNZmGVRL2a2Me+pSMH98bZWXD6EOuuijbTGbc0hOoOsbab3JdwJyr+fW7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "mobx": "^6.3.0"
-      }
-    },
     "node_modules/@jbrowse/plugin-config": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@jbrowse/plugin-config/-/plugin-config-3.7.0.tgz",
@@ -1701,15 +1638,6 @@
       "peerDependencies": {
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
-      }
-    },
-    "node_modules/@jbrowse/plugin-config/node_modules/mobx-state-tree": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.4.2.tgz",
-      "integrity": "sha512-SGXAh2KCBQbWVcxeQbZEr5pchTgcfNZmGVRL2a2Me+pSMH98bZWXD6EOuuijbTGbc0hOoOsbab3JdwJyr+fW7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "mobx": "^6.3.0"
       }
     },
     "node_modules/@jbrowse/plugin-data-management": {
@@ -1738,15 +1666,6 @@
         "react": ">=18.0.0"
       }
     },
-    "node_modules/@jbrowse/plugin-data-management/node_modules/mobx-state-tree": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.4.2.tgz",
-      "integrity": "sha512-SGXAh2KCBQbWVcxeQbZEr5pchTgcfNZmGVRL2a2Me+pSMH98bZWXD6EOuuijbTGbc0hOoOsbab3JdwJyr+fW7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "mobx": "^6.3.0"
-      }
-    },
     "node_modules/@jbrowse/plugin-gccontent": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@jbrowse/plugin-gccontent/-/plugin-gccontent-3.7.0.tgz",
@@ -1765,15 +1684,6 @@
       },
       "peerDependencies": {
         "react": ">=18.0.0"
-      }
-    },
-    "node_modules/@jbrowse/plugin-gccontent/node_modules/mobx-state-tree": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.4.2.tgz",
-      "integrity": "sha512-SGXAh2KCBQbWVcxeQbZEr5pchTgcfNZmGVRL2a2Me+pSMH98bZWXD6EOuuijbTGbc0hOoOsbab3JdwJyr+fW7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "mobx": "^6.3.0"
       }
     },
     "node_modules/@jbrowse/plugin-gff3": {
@@ -1807,15 +1717,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@jbrowse/plugin-gff3/node_modules/mobx-state-tree": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.4.2.tgz",
-      "integrity": "sha512-SGXAh2KCBQbWVcxeQbZEr5pchTgcfNZmGVRL2a2Me+pSMH98bZWXD6EOuuijbTGbc0hOoOsbab3JdwJyr+fW7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "mobx": "^6.3.0"
-      }
-    },
     "node_modules/@jbrowse/plugin-gff3/node_modules/pako-esm2": {
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/pako-esm2/-/pako-esm2-1.0.15.tgz",
@@ -1837,15 +1738,6 @@
         "mobx-state-tree": "^5.0.0",
         "rxjs": "^7.0.0",
         "set-value": "^4.0.1"
-      }
-    },
-    "node_modules/@jbrowse/plugin-legacy-jbrowse/node_modules/mobx-state-tree": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.4.2.tgz",
-      "integrity": "sha512-SGXAh2KCBQbWVcxeQbZEr5pchTgcfNZmGVRL2a2Me+pSMH98bZWXD6EOuuijbTGbc0hOoOsbab3JdwJyr+fW7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "mobx": "^6.3.0"
       }
     },
     "node_modules/@jbrowse/plugin-linear-genome-view": {
@@ -1870,15 +1762,6 @@
         "react-dom": ">=18.0.0"
       }
     },
-    "node_modules/@jbrowse/plugin-linear-genome-view/node_modules/mobx-state-tree": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.4.2.tgz",
-      "integrity": "sha512-SGXAh2KCBQbWVcxeQbZEr5pchTgcfNZmGVRL2a2Me+pSMH98bZWXD6EOuuijbTGbc0hOoOsbab3JdwJyr+fW7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "mobx": "^6.3.0"
-      }
-    },
     "node_modules/@jbrowse/plugin-sequence": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@jbrowse/plugin-sequence/-/plugin-sequence-3.7.0.tgz",
@@ -1901,15 +1784,6 @@
         "react": ">=18.0.0"
       }
     },
-    "node_modules/@jbrowse/plugin-sequence/node_modules/mobx-state-tree": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.4.2.tgz",
-      "integrity": "sha512-SGXAh2KCBQbWVcxeQbZEr5pchTgcfNZmGVRL2a2Me+pSMH98bZWXD6EOuuijbTGbc0hOoOsbab3JdwJyr+fW7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "mobx": "^6.3.0"
-      }
-    },
     "node_modules/@jbrowse/plugin-svg": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@jbrowse/plugin-svg/-/plugin-svg-3.7.0.tgz",
@@ -1927,15 +1801,6 @@
         "react": ">=18.0.0"
       }
     },
-    "node_modules/@jbrowse/plugin-svg/node_modules/mobx-state-tree": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.4.2.tgz",
-      "integrity": "sha512-SGXAh2KCBQbWVcxeQbZEr5pchTgcfNZmGVRL2a2Me+pSMH98bZWXD6EOuuijbTGbc0hOoOsbab3JdwJyr+fW7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "mobx": "^6.3.0"
-      }
-    },
     "node_modules/@jbrowse/plugin-trix": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@jbrowse/plugin-trix/-/plugin-trix-3.7.0.tgz",
@@ -1951,15 +1816,6 @@
       },
       "peerDependencies": {
         "react": ">=18.0.0"
-      }
-    },
-    "node_modules/@jbrowse/plugin-trix/node_modules/mobx-state-tree": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.4.2.tgz",
-      "integrity": "sha512-SGXAh2KCBQbWVcxeQbZEr5pchTgcfNZmGVRL2a2Me+pSMH98bZWXD6EOuuijbTGbc0hOoOsbab3JdwJyr+fW7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "mobx": "^6.3.0"
       }
     },
     "node_modules/@jbrowse/plugin-variants": {
@@ -2003,15 +1859,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@jbrowse/plugin-variants/node_modules/mobx-state-tree": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.4.2.tgz",
-      "integrity": "sha512-SGXAh2KCBQbWVcxeQbZEr5pchTgcfNZmGVRL2a2Me+pSMH98bZWXD6EOuuijbTGbc0hOoOsbab3JdwJyr+fW7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "mobx": "^6.3.0"
-      }
-    },
     "node_modules/@jbrowse/plugin-variants/node_modules/pako-esm2": {
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/pako-esm2/-/pako-esm2-1.0.15.tgz",
@@ -2045,15 +1892,6 @@
         "react": ">=18.0.0"
       }
     },
-    "node_modules/@jbrowse/plugin-wiggle/node_modules/mobx-state-tree": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.4.2.tgz",
-      "integrity": "sha512-SGXAh2KCBQbWVcxeQbZEr5pchTgcfNZmGVRL2a2Me+pSMH98bZWXD6EOuuijbTGbc0hOoOsbab3JdwJyr+fW7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "mobx": "^6.3.0"
-      }
-    },
     "node_modules/@jbrowse/product-core": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@jbrowse/product-core/-/product-core-3.7.0.tgz",
@@ -2076,15 +1914,6 @@
       "peerDependencies": {
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
-      }
-    },
-    "node_modules/@jbrowse/product-core/node_modules/mobx-state-tree": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.4.2.tgz",
-      "integrity": "sha512-SGXAh2KCBQbWVcxeQbZEr5pchTgcfNZmGVRL2a2Me+pSMH98bZWXD6EOuuijbTGbc0hOoOsbab3JdwJyr+fW7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "mobx": "^6.3.0"
       }
     },
     "node_modules/@jbrowse/quick-lru": {
@@ -2411,15 +2240,6 @@
         }
       }
     },
-    "node_modules/@jbrowse/react-linear-genome-view/node_modules/mobx-state-tree": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.4.2.tgz",
-      "integrity": "sha512-SGXAh2KCBQbWVcxeQbZEr5pchTgcfNZmGVRL2a2Me+pSMH98bZWXD6EOuuijbTGbc0hOoOsbab3JdwJyr+fW7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "mobx": "^6.3.0"
-      }
-    },
     "node_modules/@jbrowse/sv-core": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@jbrowse/sv-core/-/sv-core-3.7.0.tgz",
@@ -2440,15 +2260,6 @@
       "peerDependencies": {
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
-      }
-    },
-    "node_modules/@jbrowse/sv-core/node_modules/mobx-state-tree": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.4.2.tgz",
-      "integrity": "sha512-SGXAh2KCBQbWVcxeQbZEr5pchTgcfNZmGVRL2a2Me+pSMH98bZWXD6EOuuijbTGbc0hOoOsbab3JdwJyr+fW7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "mobx": "^6.3.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -6086,13 +5897,10 @@
       }
     },
     "node_modules/mobx-state-tree": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-7.0.2.tgz",
-      "integrity": "sha512-Qmqgo2Ho1/JRTquo0EWw0ZA/k4wTUNPMIBg98ALGN1V/0Gupic7dg4GDYUhNbiLsYHpp48VgpaCDpDIKV+jNkQ==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/mobx-state-tree/-/mobx-state-tree-5.4.2.tgz",
+      "integrity": "sha512-SGXAh2KCBQbWVcxeQbZEr5pchTgcfNZmGVRL2a2Me+pSMH98bZWXD6EOuuijbTGbc0hOoOsbab3JdwJyr+fW7Q==",
       "license": "MIT",
-      "dependencies": {
-        "ts-essentials": "^9.4.1"
-      },
       "peerDependencies": {
         "mobx": "^6.3.0"
       }
@@ -7299,20 +7107,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
-      }
-    },
-    "node_modules/ts-essentials": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-9.4.2.tgz",
-      "integrity": "sha512-mB/cDhOvD7pg3YCLk2rOtejHjjdSi9in/IBYE13S+8WA5FBSraYf4V/ws55uvs0IvQ/l0wBOlXy5yBNZ9Bl8ZQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "typescript": ">=4.1.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@jbrowse/react-linear-genome-view": "^3.1.0",
     "mobx": "^6.15.0",
     "mobx-react": "^9.2.1",
-    "mobx-state-tree": "^7.0.2",
+    "mobx-state-tree": "^5.4.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "vite-plugin-node-polyfills": "^0.25.0"


### PR DESCRIPTION
### Motivation
- The demo site rendered a blank page because the app loaded a runtime MobX-State-Tree (MST) version incompatible with JBrowse (app used MST 7.x while JBrowse packages expect 5.x), which caused a startup exception (`Identifier types can only be instantiated as direct child of a model type`).

### Description
- Updated the app dependency `mobx-state-tree` from `^7.0.2` to `^5.4.2` in `package.json` to match the MST version used by the JBrowse packages.
- Regenerated `package-lock.json` so installations resolve to the compatible MST 5.x tree.
- Committed the updated `package.json` and `package-lock.json` so CI and GitHub Pages builds use the fixed dependency graph.

### Testing
- Ran `npm ci --legacy-peer-deps` successfully to install dependencies resolving to MST 5.4.2.
- Ran `npm run build` successfully and confirmed production `dist/index.html` references the correct base path and assets.
- Launched a local preview with `npm run preview -- --host 0.0.0.0 --port 4173` and used Playwright to visit `/Jbrowse2-plugin-lab/`, which returned status `200`, the page title and `h1` text, and showed no page errors (previous MST runtime error disappeared).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1f8511900832abae987c170313e94)