### PR TITLE
Fix root index.html entry URLs to use Vite absolute paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="./vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>JBrowse2 Plugin Lab</title>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="./src/main.tsx"></script>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Static hosting (GitHub Pages) and Firefox were resolving repo-relative module paths which caused a MIME/type module loading error; using Vite-style root-absolute URLs prevents repo-relative resolution problems when serving built assets.

### Description
- Updated `index.html` to use root-absolute asset URLs for the Vite entry points by changing the favicon href from `./vite.svg` to `/vite.svg` and the module entry script from `./src/main.tsx` to `/src/main.tsx`.

### Testing
- Ran `npm run build` (which runs `tsc -b && vite build`) and the build completed successfully, producing a `dist/index.html` that references the compiled assets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2d38409c4832aabc9289f13fd077f)